### PR TITLE
Update Transforms to _Also_ Support Non-Square Images

### DIFF
--- a/melanoma_util.py
+++ b/melanoma_util.py
@@ -16,10 +16,11 @@ from tqdm import tqdm
 sigmoid = nn.Sigmoid()
 
 def get_transforms(image_size):
-
     return albumentations.Compose([
-        albumentations.Resize(image_size, image_size),
-        albumentations.Normalize()])
+        albumentations.SmallestMaxSize(image_size),
+        albumentations.CenterCrop(image_size, image_size),
+        albumentations.Normalize()
+    ])
 
 
 class MelanomaDataset(Dataset):


### PR DESCRIPTION
Swap `Resize` for `SmallestMaxSize + CenterCrop` to support non-square images as input _in addition to_ square images. 

* For images which are already square, this combination performs the same operation as a `Resize`. 
* For images which are non-square, this combination will resize the image such that the smallest of the two sides is `image_size`, before center cropping the image to `image_size x image_size`. 

This behavior aligns with the publication (Supplementary Material: Data Augmentation), and allows users to run predictions over the PROVE-AI data downloaded from ISIC Archive without requiring an additional step of center cropping all images before running the code.